### PR TITLE
FIX: Use "nickname" instead of "username" in oauth payload

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7,4 +7,5 @@ en:
   js:
     login:
       discourse_login:
-        name: "Discourse Login"
+        name: "Discourse ID"
+        title: "Login with Discourse ID"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,9 +12,6 @@ plugins:
   discourse_login_debug_auth:
     default: false
     client: false
-  discourse_login_client_button_title:
-    default: "Discourse Login"
-    client: false
   discourse_login_client_url:
     default: ""
     hidden: true

--- a/lib/discourse_login_client_authenticator.rb
+++ b/lib/discourse_login_client_authenticator.rb
@@ -15,7 +15,7 @@ class DiscourseLoginClientAuthenticator < Auth::ManagedAuthenticator
 
     info do
       {
-        username: access_token.params["info"]["username"],
+        nickname: access_token.params["info"]["username"],
         email: access_token.params["info"]["email"],
         image: access_token.params["info"]["image"],
       }

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # name: discourse-login-client
-# about: Test plugin
+# about: Test plugin for Discourse ID authentication. Currently not intended for use in production.
 # meta_topic_id: N/A
 # version: 0.0.1
 # authors: Discourse
@@ -12,6 +12,4 @@ require_relative "lib/discourse_login_client_authenticator"
 
 enabled_site_setting :discourse_login_client_enabled
 
-auth_provider title_setting: "discourse_login_client_button_title",
-              icon: "fab-discourse",
-              authenticator: DiscourseLoginClientAuthenticator.new
+auth_provider icon: "fab-discourse", authenticator: DiscourseLoginClientAuthenticator.new


### PR DESCRIPTION
This also includes a few small cosmetic fixes for labels.