### PR TITLE
FIX: automatically skip create confirm when plugin is enabled

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -14,3 +14,15 @@ require_relative "lib/discourse_login_client_authenticator"
 enabled_site_setting :discourse_login_client_enabled
 
 auth_provider icon: "fab-discourse", authenticator: DiscourseLoginClientAuthenticator.new
+
+after_initialize do
+  on_enabled_change do |_, enabled|
+    if enabled
+      SiteSetting.set(:auth_skip_create_confirm, true)
+      SiteSetting.hidden_settings_provider.add_hidden(:auth_skip_create_confirm)
+    else
+      SiteSetting.set(:auth_skip_create_confirm, false)
+      SiteSetting.hidden_settings_provider.remove_hidden(:auth_skip_create_confirm)
+    end
+  end
+end

--- a/spec/lib/site_settings_override_spec.rb
+++ b/spec/lib/site_settings_override_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "SiteSetting" do
+  it "overrides auth_skip_create_confirm only when the plugin is enabled" do
+    expect(SiteSetting.auth_skip_create_confirm).to eq(false)
+
+    SiteSetting.discourse_login_client_enabled = true
+
+    expect(SiteSetting.auth_skip_create_confirm).to eq(true)
+    expect(SiteSetting.hidden_settings).to include(:auth_skip_create_confirm)
+
+    SiteSetting.discourse_login_client_enabled = false
+
+    expect(SiteSetting.auth_skip_create_confirm).to eq(false)
+    expect(SiteSetting.hidden_settings).not_to include(:auth_skip_create_confirm)
+  end
+end


### PR DESCRIPTION
This is dependent on https://github.com/discourse/discourse/pull/32824 being merged.