### PR TITLE
FEATURE: new "revoke" endpoint

### DIFF
--- a/app/controllers/discourse_login_client/auth_controller.rb
+++ b/app/controllers/discourse_login_client/auth_controller.rb
@@ -16,7 +16,7 @@ module DiscourseLoginClient
       time_diff = (Time.now.to_i - timestamp.to_i).abs
       if time_diff > 5.minutes.to_i
         if SiteSetting.discourse_login_debug_auth
-          Rails.logger.warn("Expired timestamp in discourse_login revoke: #{time_diff} seconds old")
+          Rails.logger.warn("Expired timestamp in discourse_login_client revoke: #{time_diff} seconds old")
         end
         return render_invalid_request
       end

--- a/app/controllers/discourse_login_client/auth_controller.rb
+++ b/app/controllers/discourse_login_client/auth_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module DiscourseLoginClient
+  class AuthController < ApplicationController
+    requires_plugin "discourse-login-client"
+
+    skip_before_action :verify_authenticity_token, only: [:revoke]
+
+    def revoke
+      signature = params.require(:signature)
+      user_id = params.require(:user_id)
+      timestamp = params.require(:timestamp)
+
+      RateLimiter.new(nil, "discourse_login_revoke_#{user_id}", 5, 1.minute).performed!
+
+      time_diff = (Time.now.to_i - timestamp.to_i).abs
+      if time_diff > 5.minutes.to_i
+        if SiteSetting.discourse_login_debug_auth
+          Rails.logger.warn("Expired timestamp in discourse_login revoke: #{time_diff} seconds old")
+        end
+        return render_invalid_request
+      end
+
+      return render_invalid_request if (client_id = SiteSetting.discourse_login_client_id).blank?
+      return render_invalid_request if (client_secret = SiteSetting.discourse_login_client_secret).blank?
+
+      hashed_secret = Digest::SHA256.hexdigest(client_secret)
+
+      expected_signature =
+        OpenSSL::HMAC.hexdigest("sha256", hashed_secret, "#{client_id}:#{user_id}:#{timestamp}")
+
+      if !ActiveSupport::SecurityUtils.secure_compare(signature, expected_signature)
+        if SiteSetting.discourse_login_debug_auth
+          Rails.logger.warn("Invalid signature for user_id #{user_id} in discourse_login revoke")
+        end
+        return render_invalid_request
+      end
+
+      unless uaa = UserAssociatedAccount.find_by(provider_name: "discourse_login", provider_uid: user_id)
+        if SiteSetting.discourse_login_debug_auth
+          Rails.logger.warn("User not found with provider_uid: #{user_id}")
+        end
+        return render_invalid_request
+      end
+
+      UserAuthToken.where(user_id: uaa.user_id).destroy_all
+
+      render json: { success: true }
+    end
+
+    private
+
+    def render_invalid_request
+      render json: { error: "Invalid request" }, status: 400
+    end
+  end
+end

--- a/app/controllers/discourse_login_client/auth_controller.rb
+++ b/app/controllers/discourse_login_client/auth_controller.rb
@@ -8,37 +8,45 @@ module DiscourseLoginClient
 
     def revoke
       signature = params.require(:signature)
-      user_id = params.require(:user_id)
+      identifier = params.require(:identifier)
       timestamp = params.require(:timestamp)
 
-      RateLimiter.new(nil, "discourse_login_revoke_#{user_id}", 5, 1.minute).performed!
+      RateLimiter.new(nil, "discourse_login_revoke_#{identifier}", 5, 1.minute).performed!
 
       time_diff = (Time.now.to_i - timestamp.to_i).abs
       if time_diff > 5.minutes.to_i
         if SiteSetting.discourse_login_debug_auth
-          Rails.logger.warn("Expired timestamp in discourse_login_client revoke: #{time_diff} seconds old")
+          Rails.logger.warn(
+            "Expired timestamp in discourse_login_client revoke: #{time_diff} seconds old",
+          )
         end
         return render_invalid_request
       end
 
       return render_invalid_request if (client_id = SiteSetting.discourse_login_client_id).blank?
-      return render_invalid_request if (client_secret = SiteSetting.discourse_login_client_secret).blank?
+      if (client_secret = SiteSetting.discourse_login_client_secret).blank?
+        return render_invalid_request
+      end
 
       hashed_secret = Digest::SHA256.hexdigest(client_secret)
 
       expected_signature =
-        OpenSSL::HMAC.hexdigest("sha256", hashed_secret, "#{client_id}:#{user_id}:#{timestamp}")
+        OpenSSL::HMAC.hexdigest("sha256", hashed_secret, "#{client_id}:#{identifier}:#{timestamp}")
 
       if !ActiveSupport::SecurityUtils.secure_compare(signature, expected_signature)
         if SiteSetting.discourse_login_debug_auth
-          Rails.logger.warn("Invalid signature for user_id #{user_id} in discourse_login revoke")
+          Rails.logger.warn("Invalid signature for user id #{identifier} in discourse_login revoke")
         end
         return render_invalid_request
       end
 
-      unless uaa = UserAssociatedAccount.find_by(provider_name: "discourse_login", provider_uid: user_id)
+      unless uaa =
+               UserAssociatedAccount.find_by(
+                 provider_name: "discourse_login",
+                 provider_uid: identifier,
+               )
         if SiteSetting.discourse_login_debug_auth
-          Rails.logger.warn("User not found with provider_uid: #{user_id}")
+          Rails.logger.warn("User not found with provider_uid: #{identifier}")
         end
         return render_invalid_request
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,10 +2,8 @@
 
 # name: discourse-login-client
 # about: Test plugin for Discourse ID authentication. Currently not intended for use in production.
-# meta_topic_id: N/A
 # version: 0.0.1
 # authors: Discourse
-# url: TODO
 # required_version: 3.3.0
 
 require_relative "lib/discourse_login_client_strategy"
@@ -16,6 +14,8 @@ enabled_site_setting :discourse_login_client_enabled
 auth_provider icon: "fab-discourse", authenticator: DiscourseLoginClientAuthenticator.new
 
 after_initialize do
+  require_relative "app/controllers/discourse_login_client/auth_controller"
+
   on_enabled_change do |_, enabled|
     if enabled
       SiteSetting.set(:auth_skip_create_confirm, true)
@@ -24,5 +24,9 @@ after_initialize do
       SiteSetting.set(:auth_skip_create_confirm, false)
       SiteSetting.hidden_settings_provider.remove_hidden(:auth_skip_create_confirm)
     end
+  end
+
+  Discourse::Application.routes.append do
+    post "/auth/discourse_login/revoke" => "discourse_login_client/auth#revoke"
   end
 end

--- a/spec/requests/discourse_login_client/auth_controller_spec.rb
+++ b/spec/requests/discourse_login_client/auth_controller_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+RSpec.describe ::DiscourseLoginClient::AuthController do
+  let(:client_id) { SiteSetting.discourse_login_client_id }
+  let(:hashed_secret) { Digest::SHA256.hexdigest(SiteSetting.discourse_login_client_secret) }
+  let(:user_id) { SecureRandom.hex }
+  let(:provider_name) { "discourse_login" }
+
+  let!(:user) { Fabricate(:user) }
+  let!(:user_associated_account) { Fabricate(:user_associated_account, user:, provider_name:, provider_uid: user_id) }
+
+  before do
+    SiteSetting.discourse_login_client_enabled = true
+    SiteSetting.discourse_login_client_id = SecureRandom.hex
+    SiteSetting.discourse_login_client_secret = SecureRandom.hex
+  end
+
+  describe "#revoke" do
+    context "with valid parameters" do
+      it "revokes all auth tokens for the user" do
+        UserAuthToken.generate!(user_id: user.id)
+        UserAuthToken.generate!(user_id: user.id)
+
+        expect(UserAuthToken.where(user_id: user.id).count).to eq(2)
+
+        timestamp = Time.now.to_i
+        signature =
+          OpenSSL::HMAC.hexdigest(
+            "sha256",
+            hashed_secret,
+            "#{client_id}:#{user_id}:#{timestamp}",
+          )
+
+        post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq(true)
+
+        expect(UserAuthToken.where(user_id: user.id).count).to eq(0)
+      end
+    end
+
+    context "with invalid parameters" do
+      it "returns 400 when signature is invalid" do
+        timestamp = Time.now.to_i
+        signature = SecureRandom.hex
+
+        post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("Invalid request")
+
+        post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+
+        expect(response.status).to eq(400)
+      end
+
+      it "returns 400 when timestamp is too old" do
+        timestamp = Time.now.to_i - 6.minutes.to_i
+        signature =
+          OpenSSL::HMAC.hexdigest(
+            "sha256",
+            hashed_secret,
+            "#{client_id}:#{user_id}:#{timestamp}",
+          )
+
+        post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("Invalid request")
+      end
+
+      it "returns 400 when user_id is not found" do
+        user_id = "non_existent_user_id"
+        timestamp = Time.now.to_i
+        signature =
+          OpenSSL::HMAC.hexdigest(
+            "sha256",
+            hashed_secret,
+            "#{client_id}:#{user_id}:#{timestamp}",
+          )
+
+        post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("Invalid request")
+      end
+
+      it "returns 400 when client_id or client_secret is blank" do
+        SiteSetting.discourse_login_client_id = ""
+
+        timestamp = Time.now.to_i
+        signature =
+          OpenSSL::HMAC.hexdigest(
+            "sha256",
+            hashed_secret,
+            "#{client_id}:#{user_id}:#{timestamp}",
+          )
+
+        post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("Invalid request")
+
+        SiteSetting.discourse_login_client_id = SecureRandom.hex
+        SiteSetting.discourse_login_client_secret = ""
+
+        post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["error"]).to eq("Invalid request")
+      end
+    end
+
+    context "with rate limiting" do
+      before { RateLimiter.enable }
+
+      it "rate limits after 5 requests per minute for the same user_id" do
+        user_id = "non_existent_user_id"
+        timestamp = Time.now.to_i
+        signature = SecureRandom.hex
+
+        5.times do
+          post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+          expect(response.status).to eq(400)
+        end
+
+        post "/auth/discourse_login/revoke.json", params: { signature:, user_id:, timestamp: }
+        expect(response.status).to eq(429)
+      end
+    end
+  end
+end

--- a/spec/system/discourse_login_client_spec.rb
+++ b/spec/system/discourse_login_client_spec.rb
@@ -27,7 +27,7 @@ describe "discourse login client auth" do
   let(:signup_form) { PageObjects::Pages::Signup.new }
 
   context "when user does not exist" do
-    it "skips the signup form & create the account directly" do
+    it "skips the signup form and creates the account directly" do
       visit("/")
       signup_form.open.click_social_button("discourse_login")
       expect(page).to have_css(".header-dropdown-toggle.current-user")

--- a/spec/system/discourse_login_client_spec.rb
+++ b/spec/system/discourse_login_client_spec.rb
@@ -24,47 +24,23 @@ describe "discourse login client auth" do
 
   after { reset_omniauth_config(:discourse_login) }
 
-  let(:login_form) { PageObjects::Pages::Login.new }
   let(:signup_form) { PageObjects::Pages::Signup.new }
 
   context "when user does not exist" do
-    it "fills the signup form" do
+    it "skips the signup form & create the account directly" do
       visit("/")
-
       signup_form.open.click_social_button("discourse_login")
-      expect(signup_form).to be_open
-      expect(signup_form).to have_no_password_input
-      expect(signup_form).to have_valid_username
-      expect(signup_form).to have_valid_email
-      signup_form.click_create_account
       expect(page).to have_css(".header-dropdown-toggle.current-user")
-    end
-
-    context "when skipping the signup form" do
-      before { SiteSetting.auth_skip_create_confirm = true }
-
-      it "creates the account directly" do
-        visit("/")
-
-        signup_form.open.click_social_button("discourse_login")
-        expect(page).to have_css(".header-dropdown-toggle.current-user")
-      end
     end
   end
 
   context "when user exists" do
     fab!(:user) do
-      Fabricate(
-        :user,
-        email: OmniauthHelpers::EMAIL,
-        username: OmniauthHelpers::USERNAME,
-        password: "supersecurepassword",
-      )
+      Fabricate(:user, email: OmniauthHelpers::EMAIL, username: OmniauthHelpers::USERNAME)
     end
 
     it "logs in user" do
       visit("/")
-
       signup_form.open.click_social_button("discourse_login")
       expect(page).to have_css(".header-dropdown-toggle.current-user")
     end


### PR DESCRIPTION
that will allow the provider to revoke all the auth tokens, aka logs out the user, whenever they revoke a community from the provider's side

Internal ref - t/153564

Related - https://github.com/discourse/discourse-login/pull/31