### PR TITLE
DEV: rename site setting

### DIFF
--- a/app/controllers/discourse_login_client/auth_controller.rb
+++ b/app/controllers/discourse_login_client/auth_controller.rb
@@ -15,15 +15,17 @@ module DiscourseLoginClient
 
       time_diff = (Time.now.to_i - timestamp.to_i).abs
       if time_diff > 5.minutes.to_i
-        if SiteSetting.discourse_login_debug_auth
+        if SiteSetting.discourse_login_client_verbose_logging
           Rails.logger.warn(
             "Expired timestamp in discourse_login_client revoke: #{time_diff} seconds old",
           )
         end
+
         return render_invalid_request
       end
 
       return render_invalid_request if (client_id = SiteSetting.discourse_login_client_id).blank?
+
       if (client_secret = SiteSetting.discourse_login_client_secret).blank?
         return render_invalid_request
       end
@@ -34,9 +36,10 @@ module DiscourseLoginClient
         OpenSSL::HMAC.hexdigest("sha256", hashed_secret, "#{client_id}:#{identifier}:#{timestamp}")
 
       if !ActiveSupport::SecurityUtils.secure_compare(signature, expected_signature)
-        if SiteSetting.discourse_login_debug_auth
+        if SiteSetting.discourse_login_client_verbose_logging
           Rails.logger.warn("Invalid signature for user id #{identifier} in discourse_login revoke")
         end
+
         return render_invalid_request
       end
 
@@ -45,9 +48,10 @@ module DiscourseLoginClient
                  provider_name: "discourse_login",
                  provider_uid: identifier,
                )
-        if SiteSetting.discourse_login_debug_auth
+        if SiteSetting.discourse_login_client_verbose_logging
           Rails.logger.warn("User not found with provider_uid: #{identifier}")
         end
+
         return render_invalid_request
       end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,7 +9,7 @@ plugins:
     default: ""
     client: false
     secret: true
-  discourse_login_debug_auth:
+  discourse_login_client_verbose_logging:
     default: false
     client: false
   discourse_login_client_url:

--- a/db/migrate/20250523000000_rename_discourse_login_debug_auth_site_setting.rb
+++ b/db/migrate/20250523000000_rename_discourse_login_debug_auth_site_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RenameDiscourseLoginDebugAuthSiteSetting < ActiveRecord::Migration[7.2]
+  def up
+    execute "UPDATE site_settings SET name = 'discourse_login_client_verbose_logging' WHERE name = 'discourse_login_debug_auth'"
+  end
+
+  def down
+    execute "UPDATE site_settings SET name = 'discourse_login_debug_auth' WHERE name = 'discourse_login_client_verbose_logging'"
+  end
+end


### PR DESCRIPTION
From `discourse_login_debug_auth` to `discourse_login_client_verbose_logging`