### PR TITLE
UX: Show a "Continue with Discourse ID" button

### DIFF
--- a/assets/javascripts/initializers/continue-with.gjs
+++ b/assets/javascripts/initializers/continue-with.gjs
@@ -1,0 +1,27 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import DButton from "discourse/components/d-button";
+
+export default {
+  initialize(container) {
+    const { isOnlyOneExternalLoginMethod, externalLoginMethods, singleExternalLogin } = container.lookup("service:login");
+    const onlyDiscourseId = isOnlyOneExternalLoginMethod && externalLoginMethods[0].name === "discourse_login";
+
+    withPluginApi("2.1.1", ({ headerButtons }) => {
+      if (onlyDiscourseId) {
+        const currentUser = container.lookup("service:current-user");
+
+        headerButtons.delete("auth");
+        headerButtons.add("continue-with", <template>
+          {{#unless currentUser}}
+            <DButton
+              class="continue-with-discourse"
+              @icon="fab-discourse"
+              @label="discourse_login.continue_with"
+              @action={{singleExternalLogin}}
+            />
+          {{/unless}}
+        </template>);
+      }
+    });
+  }
+}

--- a/assets/javascripts/initializers/continue-with.gjs
+++ b/assets/javascripts/initializers/continue-with.gjs
@@ -6,7 +6,7 @@ export default {
     const { isOnlyOneExternalLoginMethod, externalLoginMethods, singleExternalLogin } = container.lookup("service:login");
     const onlyDiscourseId = isOnlyOneExternalLoginMethod && externalLoginMethods[0].name === "discourse_login";
 
-    withPluginApi("2.1.1", ({ headerButtons }) => {
+    withPluginApi(({ headerButtons }) => {
       if (onlyDiscourseId) {
         const currentUser = container.lookup("service:current-user");
 

--- a/assets/javascripts/initializers/continue-with.gjs
+++ b/assets/javascripts/initializers/continue-with.gjs
@@ -14,7 +14,7 @@ export default {
         headerButtons.add("continue-with", <template>
           {{#unless currentUser}}
             <DButton
-              class="continue-with-discourse"
+              class="continue-with-discourse btn-primary"
               @icon="fab-discourse"
               @label="discourse_login.continue_with"
               @action={{singleExternalLogin}}

--- a/assets/javascripts/initializers/continue-with.gjs
+++ b/assets/javascripts/initializers/continue-with.gjs
@@ -6,9 +6,9 @@ export default {
     const { isOnlyOneExternalLoginMethod, externalLoginMethods, singleExternalLogin } = container.lookup("service:login");
     const onlyDiscourseId = isOnlyOneExternalLoginMethod && externalLoginMethods[0].name === "discourse_login";
 
-    withPluginApi(({ headerButtons }) => {
+    withPluginApi(({ headerButtons, getCurrentUser }) => {
       if (onlyDiscourseId) {
-        const currentUser = container.lookup("service:current-user");
+        const currentUser = getCurrentUser();
 
         headerButtons.delete("auth");
         headerButtons.add("continue-with", <template>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9,3 +9,5 @@ en:
       discourse_login:
         name: "Discourse ID"
         title: "Login with Discourse ID"
+    discourse_login:
+      continue_with: "Continue with Discourse ID"

--- a/spec/system/discourse_login_client_spec.rb
+++ b/spec/system/discourse_login_client_spec.rb
@@ -45,4 +45,38 @@ describe "discourse login client auth" do
       expect(page).to have_css(".header-dropdown-toggle.current-user")
     end
   end
+
+  context "when discourse_login is the only external login method" do
+    before do
+      SiteSetting.enable_discord_logins = false
+      SiteSetting.enable_facebook_logins = false
+      SiteSetting.enable_github_logins = false
+      SiteSetting.enable_google_oauth2_logins = false
+      SiteSetting.enable_linkedin_oidc_logins = false
+      SiteSetting.enable_local_logins = false
+      SiteSetting.enable_twitter_logins = false
+    end
+
+    it "hides regular auth buttons and shows continue with discourse id button" do
+      visit("/")
+
+      expect(page).not_to have_css(".auth-buttons .sign-up-button")
+      expect(page).not_to have_css(".auth-buttons .login-button")
+
+      expect(page).to have_css(
+        ".continue-with-discourse",
+        text: I18n.t("js.discourse_login.continue_with"),
+      )
+    end
+
+    it "continues with discourse login when button is clicked" do
+      visit("/")
+
+      page.find(".continue-with-discourse").click
+
+      expect(page).to have_css(".header-dropdown-toggle.current-user")
+
+      expect(page).not_to have_css(".continue-with-discourse")
+    end
+  end
 end


### PR DESCRIPTION
...instead of the usual Login / Sign Up button to visitors.

Internal ref - t/154881

---

**BEFORE**

![Screenshot 2025-05-27 at 16 05 52](https://github.com/user-attachments/assets/ec5c7bf9-1296-473a-80d2-fd9866e5ee3e)

**AFTER**

![Screenshot 2025-05-27 at 16 05 00](https://github.com/user-attachments/assets/2a96fc78-3a00-4468-aa26-5851b68cc9fb)
